### PR TITLE
make Rigidbody a required component of NVRInteractable

### DIFF
--- a/Assets/NewtonVR/NVRInteractable.cs
+++ b/Assets/NewtonVR/NVRInteractable.cs
@@ -3,6 +3,7 @@ using System.Collections;
 
 namespace NewtonVR
 {
+    [RequireComponent (typeof (Rigidbody))]
     public abstract class NVRInteractable : MonoBehaviour
     {
         public Rigidbody Rigidbody;


### PR DESCRIPTION
makes Unity automatically add a Rigidbody to the object when you add an NVRInteractable behavior and is more semantically correct
