### PR TITLE
Add collision layers, target and exposed end position to laser pointer

### DIFF
--- a/Assets/NewtonVR/Example/NVRExampleLaserPointer.cs
+++ b/Assets/NewtonVR/Example/NVRExampleLaserPointer.cs
@@ -11,6 +11,10 @@ namespace NewtonVR.Example
 
         public bool OnlyVisibleOnTrigger = true;
 
+        public LayerMask CollideWithLayers;
+        public Transform Target;
+        public Vector3 EndPosition;
+
         private LineRenderer Line;
 
         private NVRHand Hand;
@@ -46,19 +50,19 @@ namespace NewtonVR.Example
                 Line.SetWidth(LineWidth, LineWidth);
 
                 RaycastHit hitInfo;
-                bool hit = Physics.Raycast(this.transform.position, this.transform.forward, out hitInfo, 1000);
-                Vector3 endPoint;
+                bool hit = Physics.Raycast(this.transform.position, this.transform.forward, out hitInfo, 1000, CollideWithLayers);
 
                 if (hit == true)
                 {
-                    endPoint = hitInfo.point;
+                    EndPosition = hitInfo.point;
+                    Target = hitInfo.transform;
                 }
                 else
                 {
-                    endPoint = this.transform.position + (this.transform.forward * 1000f);
+                    EndPosition = this.transform.position + (this.transform.forward * 1000f);
                 }
 
-                Line.SetPositions(new Vector3[] { this.transform.position, endPoint });
+                Line.SetPositions(new Vector3[] { this.transform.position, EndPosition });
             }
         }
     }


### PR DESCRIPTION
This allows the object the pointer is pointing at to be queried, along with the exact collision point (eg for positioning markers or particle effects). Also add configurable collision layers to the pointer can pass through (eg transparent) objects where required.

(Side note: LineRenderer seems to have a bug in the latest Unity 5.4 betas that makes it render in only one eye - it's not clear if this will be fixed or if future laser pointer examples should instead use a mesh, like the cube used in Valves example).
