### PR TITLE
Fix some null reference exceptions when deregistering interactables.

### DIFF
--- a/Assets/NewtonVR/NVRHand.cs
+++ b/Assets/NewtonVR/NVRHand.cs
@@ -512,10 +512,13 @@ namespace NewtonVR
 
         public void DeregisterInteractable(NVRInteractable interactable)
         {
+            if (interactable == null) return;
+
             if (CurrentlyInteracting == interactable)
                 CurrentlyInteracting = null;
 
-            if (CurrentlyHoveringOver != null)
+            if (CurrentlyHoveringOver != null && 
+                CurrentlyHoveringOver.ContainsKey(interactable))
                 CurrentlyHoveringOver.Remove(interactable);
         }
 

--- a/Assets/NewtonVR/NVRPlayer.cs
+++ b/Assets/NewtonVR/NVRPlayer.cs
@@ -64,7 +64,10 @@ namespace NewtonVR
         {
             for (int index = 0; index < Instance.Hands.Length; index++)
             {
-                Instance.Hands[index].DeregisterInteractable(interactable);
+                if (Instance.Hands[index] != null)
+                {
+                    Instance.Hands[index].DeregisterInteractable(interactable);
+                }
             }
         }
     }


### PR DESCRIPTION
These appear mostly harmless apart from crufting up the console messages in the editor when you press stop, but it's better to have them caught IMO since I expect the there could be cases where they result in a real bug.
