### PR TITLE
Small fix for NVRInteractableRotator.CurrentAngle

### DIFF
--- a/Assets/NewtonVR/NVRInteractableRotator.cs
+++ b/Assets/NewtonVR/NVRInteractableRotator.cs
@@ -27,7 +27,7 @@ namespace NewtonVR
                 this.Rigidbody.AddForceAtPosition(PositionDelta, InitialAttachPoint.position, ForceMode.VelocityChange);
             }
 
-            CurrentAngle = this.transform.localEulerAngles.z;
+            CurrentAngle = Quaternion.Angle(Quaternion.identity, this.transform.rotation);
         }
 
         public override void BeginInteraction(NVRHand hand)

--- a/Assets/NewtonVR/NVRInteractableRotator.cs
+++ b/Assets/NewtonVR/NVRInteractableRotator.cs
@@ -16,6 +16,12 @@ namespace NewtonVR
             this.Rigidbody.maxAngularVelocity = 100f;
         }
 
+        protected override void Update()
+        {
+            base.Update();
+            CurrentAngle = Quaternion.Angle(Quaternion.identity, this.transform.rotation);
+        }
+
         public override void OnNewPosesApplied()
         {
             base.OnNewPosesApplied();


### PR DESCRIPTION
I ran into two small issues with NVRInteractableRotator.CurrentAngle which are addressed in this PR:
1. CurrentAngle was only ever measured as a rotation about the Z axis. A rotator configured to rotate around another axis would either always have a rotation of 0. This is resolved by measuring CurrentAngle with `Quaternion.Angle(Quaternion.identity, this.transform.rotation)`.
2. CurrentAngle was only updated through direct user interaction. If the rotator was moved (e.g. through another script, physics interaction, or direct manipulation in the editor during play mode) the new angle would not be updated until the user touched it. This is resolved by computing CurrentAngle in Update().
