### PR TITLE
Wwise Sound Engine provider for the Collision Sounds framework

### DIFF
--- a/Assets/NewtonVR/CollisionSoundFramework/Editor/NVRCollisionSoundControllerEditor.cs
+++ b/Assets/NewtonVR/CollisionSoundFramework/Editor/NVRCollisionSoundControllerEditor.cs
@@ -28,6 +28,13 @@ namespace NewtonVR
     public class NVRCollisionSoundControllerEditor : Editor
     {
         private const string FMODDefine = "NVR_FMOD";
+        //---
+        // @ROGUESUN BEGIN: Ben - Wwise support
+        //---
+        private const string WwiseDefine = "NVR_WWISE";
+        //---
+        // @ROGUESUN END
+        //---
 
         private static bool hasReloaded = false;
         private static bool waitingForReload = false;
@@ -36,6 +43,8 @@ namespace NewtonVR
         private static bool hasFMODSDK = false;
         //private static bool hasFMODDefine = false;
 
+        private static bool hasWwiseSDK = false;
+
         private static string progressBarMessage = null;
 
         [DidReloadScripts]
@@ -43,6 +52,8 @@ namespace NewtonVR
         {
             hasReloaded = true;
             hasFMODSDK = DoesTypeExist("FMODPlatform");
+
+            hasWwiseSDK = DoesTypeExist("AkSoundEngine");
 
             //string scriptingDefine = PlayerSettings.GetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone);
             //string[] scriptingDefines = scriptingDefine.Split(';');
@@ -133,9 +144,12 @@ namespace NewtonVR
                 HasWaitedLongEnough();
 
             bool installFMOD = false;
+            bool installWwise = false;
             bool isFMODEnabled = controller.SoundEngine == NVRCollisionSoundProviders.FMOD;
+            bool isWwiseEnabled = controller.SoundEngine == NVRCollisionSoundProviders.Wwise;
             bool isUnityEnabled = controller.SoundEngine == NVRCollisionSoundProviders.Unity;
             bool enableFMOD = controller.SoundEngine == NVRCollisionSoundProviders.FMOD;
+            bool enableWwise = controller.SoundEngine == NVRCollisionSoundProviders.Wwise;
             bool enableUnity = controller.SoundEngine == NVRCollisionSoundProviders.Unity;
 
 
@@ -153,7 +167,22 @@ namespace NewtonVR
                 enableFMOD = EditorGUILayout.Toggle("Use FMOD", enableFMOD);
             }
             EditorGUILayout.EndHorizontal();
-            
+
+            EditorGUILayout.BeginHorizontal();
+            if (hasWwiseSDK == false)
+            {
+                using (new EditorGUI.DisabledScope(hasWwiseSDK == false))
+                {
+                    EditorGUILayout.Toggle("Use Wwise", false);
+                }
+                installWwise = GUILayout.Button("Install Wwise");
+            }
+            else
+            {
+                enableWwise = EditorGUILayout.Toggle("Use Wwise", enableWwise);
+            }
+            EditorGUILayout.EndHorizontal();
+
             EditorGUILayout.BeginHorizontal();
             enableUnity = EditorGUILayout.Toggle("Use Unity Sound", enableUnity);
             EditorGUILayout.EndHorizontal();
@@ -174,15 +203,27 @@ namespace NewtonVR
                 controller.SoundEngine = NVRCollisionSoundProviders.FMOD;
             }
 
+            if (enableWwise == false && isWwiseEnabled == true)
+            {
+                RemoveDefine(WwiseDefine);
+                controller.SoundEngine = NVRCollisionSoundProviders.None;
+            }
+            else if (enableWwise == true && isWwiseEnabled == false)
+            {
+                AddDefine(WwiseDefine);
+                controller.SoundEngine = NVRCollisionSoundProviders.Wwise;
+            }
 
             if (enableUnity == false && isUnityEnabled == true)
             {
                 RemoveDefine(FMODDefine);
+                RemoveDefine(WwiseDefine);
                 controller.SoundEngine = NVRCollisionSoundProviders.None;
             }
             else if (enableUnity == true && isUnityEnabled == false)
             {
                 RemoveDefine(FMODDefine);
+                RemoveDefine(WwiseDefine);
                 controller.SoundEngine = NVRCollisionSoundProviders.Unity;
             }
             
@@ -191,7 +232,10 @@ namespace NewtonVR
             {
                 Application.OpenURL("http://www.fmod.org/download/");
             }
-            
+            if (installWwise == true)
+            {
+                Application.OpenURL("https://www.audiokinetic.com/download/");
+            }
 
             DrawDefaultInspector();
 

--- a/Assets/NewtonVR/CollisionSoundFramework/NVRCollisionSoundController.cs
+++ b/Assets/NewtonVR/CollisionSoundFramework/NVRCollisionSoundController.cs
@@ -29,9 +29,11 @@ namespace NewtonVR
         {
             Instance = this;
 
-            #if NVR_FMOD
+#if NVR_FMOD
             Provider = this.gameObject.AddComponent<NVRCollisionSoundProviderFMOD>();
-            #else
+#elif NVR_WWISE
+            Provider = this.gameObject.AddComponent<NVRCollisionSoundProviderWwise>();
+#else
             Provider = this.gameObject.AddComponent<NVRCollisionSoundProviderUnity>();
             #endif
         }
@@ -48,5 +50,6 @@ namespace NewtonVR
         None,
         Unity,
         FMOD,
+        Wwise
     }
 }

--- a/Assets/NewtonVR/CollisionSoundFramework/NVRCollisionSoundProviderWwise.cs
+++ b/Assets/NewtonVR/CollisionSoundFramework/NVRCollisionSoundProviderWwise.cs
@@ -1,0 +1,241 @@
+﻿using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+
+#if NVR_WWISE
+
+namespace NewtonVR
+{
+    public class NVRCollisionSoundProviderWwise : NVRCollisionSoundProvider
+    {
+        private const string kSoundEventPrefix = "Play_sfx_collision_";
+        private const string kImpactVolumeControlName = "impactVolume";
+        private static string AudioSourcePrefabPath = "WwiseCollisionSoundPrefab";
+        private GameObject AudioSourcePrefab;
+
+        private AkGameObj[] AudioPool;
+        private int CurrentPoolIndex;
+        private uint mImpactVolumeControlId;
+
+        public bool showCollisions;
+
+        private bool mWwiseAvailable;
+
+        private static Dictionary<NVRCollisionSoundMaterials, string> eventStrings;
+        public static Dictionary<NVRCollisionSoundMaterials, string> EventStrings
+        {
+            get
+            {
+                if (eventStrings == null)
+                {
+                    eventStrings = new Dictionary<NVRCollisionSoundMaterials, string>(new EnumEqualityComparer<NVRCollisionSoundMaterials>());
+
+                    foreach (NVRCollisionSoundMaterials mat in NVRCollisionSoundMaterialsList.List)
+                    {
+                        if (mat == NVRCollisionSoundMaterials.EndNewtonVRMaterials)
+                        {
+                            continue;
+                        }
+
+                        string event_name = string.Format(kSoundEventPrefix + "{0}", mat.ToString());
+                        eventStrings.Add(mat, event_name);
+                        //Debug.Log("Generated event name for \"" + mat.ToString() + "\": \"" + event_name + "\"");
+                    }
+                }
+                return eventStrings;
+            }
+        }
+
+#if false
+        private static Dictionary<NVRCollisionSoundMaterials, uint> eventIds;
+        public static Dictionary<NVRCollisionSoundMaterials, uint> EventIds
+        {
+            get
+            {
+                if (eventIds == null)
+                {
+                    eventIds = new Dictionary<NVRCollisionSoundMaterials, uint>(new EnumEqualityComparer<NVRCollisionSoundMaterials>());
+
+                    foreach (var mat in EventStrings)
+                    {
+                        if (mat.Key == NVRCollisionSoundMaterials.EndNewtonVRMaterials)
+                        {
+                            continue;
+                        }
+
+                        Debug.Log("Would be adding event id for \""+ mat.Key + "\"");
+                        uint event_id = AkSoundEngine.GetIDFromString(mat.Value);
+                        // FIXME: everything is using Play_sfx_brick_scrape for testing.
+                        //uint event_id = AkSoundEngine.GetIDFromString("Play_sfx_brick_scrape");
+                        eventIds.Add(mat.Key, event_id);
+
+                        Debug.Log("Would be adding event id for \"" + mat.Value + "\" " + event_id);
+                    }
+                }
+                return eventIds;
+            }
+        }
+#endif
+
+        public override void Awake()
+        {
+            if (!AkSoundEngine.IsInitialized())
+            {
+                //
+                // Check to see if the AkInitializer is in the scene
+                //
+                AkInitializer initializer = GameObject.FindObjectOfType<AkInitializer>();
+
+                if (initializer == null)
+                {
+                    mWwiseAvailable = false;
+                    Debug.LogError("Trying to use Wwise NewtonVR collision sounds but no AkInitializer in scene");
+                    return;
+                }
+
+                Debug.LogWarning("Wwise NewtonVR collision sounds framework awake but Wwise not yet initialised");
+            }
+            mWwiseAvailable = true;
+            AudioPool = new AkGameObj[NVRCollisionSoundController.Instance.SoundPoolSize];
+
+            AudioSourcePrefab = Resources.Load<GameObject>(AudioSourcePrefabPath);
+
+            for (int index = 0; index < AudioPool.Length; index++)
+            {
+                AudioPool[index] = GameObject.Instantiate<GameObject>(AudioSourcePrefab).GetComponent<AkGameObj>();
+                AudioPool[index].transform.parent = this.transform;
+
+                //
+                // Disable the AkGameObjs until they are actually in use
+                //
+                AudioPool[index].gameObject.SetActive(false);
+            }
+
+            mImpactVolumeControlId = AkSoundEngine.GetIDFromString(kImpactVolumeControlName);
+        }
+
+        public override void Play(NVRCollisionSoundMaterials material, Vector3 position, float impactVolume)
+        {
+            if (!mWwiseAvailable)
+            {
+                return;
+            }
+            if (material == NVRCollisionSoundMaterials.none)
+                return;
+
+#if true
+            string event_name = EventStrings[material];
+
+            AkGameObj game_obj = AudioPool[CurrentPoolIndex];
+            CurrentPoolIndex++;
+            if (CurrentPoolIndex >= AudioPool.Length)
+            {
+                CurrentPoolIndex = 0;
+            }
+
+            game_obj.gameObject.SetActive(true);
+            Collider collider = game_obj.GetComponent<Collider>();
+            if (collider != null)
+            {
+                collider.enabled = true;
+            }
+
+            if (showCollisions)
+            {
+                MeshRenderer renderer = game_obj.GetComponent<MeshRenderer>();
+                if (renderer != null)
+                {
+                    renderer.enabled = true;
+                }
+            }
+
+            //
+            // Position the object and post the event.
+            //
+            game_obj.transform.position = position;
+
+            //
+            // use the impactVolume to control the sound
+            //
+            float impact_value = impactVolume * 100.0f;
+            //Debug.Log("impactVolume = " + impactVolume);
+            AkSoundEngine.SetRTPCValue(mImpactVolumeControlId, impact_value, AudioPool[CurrentPoolIndex].gameObject);
+
+            //Debug.Log("Position in Unity: " + AudioPool[CurrentPoolIndex].transform.position +
+            //    " position in Wise: " + AudioPool[CurrentPoolIndex].GetPosition());
+            AkSoundEngine.PostEvent(event_name, AudioPool[CurrentPoolIndex].gameObject,
+                (uint)AkCallbackType.AK_EndOfEvent, DisableGameObjectCallback, game_obj);
+
+#else
+            uint event_id = EventIds[material];
+            if (event_id != AkSoundEngine.AK_INVALID_UNIQUE_ID)
+            {
+                //
+                // Position the object and post the event.
+                //
+                AudioPool[CurrentPoolIndex].transform.position = position;
+
+                //
+                // FIXME: need some sort of control for the impactVolume
+                //
+                //Debug.Log("Position in Unity: " + AudioPool[CurrentPoolIndex].transform.position +
+                //    " position in Wise: " + AudioPool[CurrentPoolIndex].GetPosition());
+                AkSoundEngine.PostEvent(event_id, AudioPool[CurrentPoolIndex].gameObject);
+
+                CurrentPoolIndex++;
+
+                if (CurrentPoolIndex >= AudioPool.Length)
+                {
+                    CurrentPoolIndex = 0;
+                }
+            }
+#endif
+        }
+
+        void DisableGameObjectCallback(object in_cookie, AkCallbackType in_type, object in_info)
+        {
+            //Debug.Log("Hello from the callback");
+            if (in_type == AkCallbackType.AK_EndOfEvent)
+            {
+                //Debug.Log("Event has ended");
+                AkGameObj game_obj = in_cookie as AkGameObj;
+                if (game_obj != null)
+                {
+                    //
+                    // Disable the collider and GameObject to save processing the object
+                    // whilst it is not doing anything.
+                    //
+                    Collider collider = game_obj.GetComponent<Collider>();
+                    if (collider != null)
+                    {
+                        collider.enabled = false;
+                    }
+
+                    MeshRenderer renderer = game_obj.GetComponent<MeshRenderer>();
+                    if (renderer != null)
+                    {
+                        renderer.enabled = false;
+                    }
+                    game_obj.gameObject.SetActive(false);
+                }
+            }
+        }
+    }
+}
+#else
+
+    namespace NewtonVR
+{
+    public class NVRCollisionSoundProviderWwise : NVRCollisionSoundProvider
+    {
+        public override void Awake()
+        {
+        }
+
+        public override void Play(NVRCollisionSoundMaterials material, Vector3 position, float impactVolume)
+        {
+            return;
+        }
+    }
+}
+#endif

--- a/Assets/NewtonVR/CollisionSoundFramework/NVRCollisionSoundProviderWwise.cs.meta
+++ b/Assets/NewtonVR/CollisionSoundFramework/NVRCollisionSoundProviderWwise.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3df9b17dcd41be844b4ad18d86cac291
+timeCreated: 1487016974
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NewtonVR/Resources/WwiseCollisionSoundPrefab.prefab
+++ b/Assets/NewtonVR/Resources/WwiseCollisionSoundPrefab.prefab
@@ -23,7 +23,7 @@ GameObject:
   - component: {fileID: 135613616579332808}
   - component: {fileID: 23563966296978462}
   - component: {fileID: 54349115421137502}
-  - component: {fileID: 114061680384917510}
+  - component: {fileID: 114560512069717974}
   m_Layer: 11
   m_Name: WwiseCollisionSoundPrefab
   m_TagString: Untagged
@@ -97,7 +97,7 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!114 &114061680384917510
+--- !u!114 &114560512069717974
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
@@ -105,7 +105,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1482660113103954}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6876619c2c0ac0c41a14a18f04a0a571, type: 3}
+  m_Script: {fileID: 11500000, guid: 82f7efd21bfd38449b524cb45c06a4a7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_positionOffsetData:
@@ -114,6 +114,7 @@ MonoBehaviour:
   isEnvironmentAware: 1
   listenerMask: 1
   isStaticObject: 0
+  m_posOffsetData: {fileID: 0}
 --- !u!135 &135613616579332808
 SphereCollider:
   m_ObjectHideFlags: 1

--- a/Assets/NewtonVR/Resources/WwiseCollisionSoundPrefab.prefab
+++ b/Assets/NewtonVR/Resources/WwiseCollisionSoundPrefab.prefab
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1482660113103954}
+  m_IsPrefabParent: 1
+--- !u!1 &1482660113103954
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4676350682495138}
+  - component: {fileID: 33095656065509238}
+  - component: {fileID: 135613616579332808}
+  - component: {fileID: 23563966296978462}
+  - component: {fileID: 54349115421137502}
+  - component: {fileID: 114061680384917510}
+  m_Layer: 11
+  m_Name: WwiseCollisionSoundPrefab
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4676350682495138
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1482660113103954}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &23563966296978462
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1482660113103954}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+--- !u!33 &33095656065509238
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1482660113103954}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!54 &54349115421137502
+Rigidbody:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1482660113103954}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &114061680384917510
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1482660113103954}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6876619c2c0ac0c41a14a18f04a0a571, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_positionOffsetData:
+    positionOffset: {x: 0, y: 0, z: 0}
+    KeepMe: 0
+  isEnvironmentAware: 1
+  listenerMask: 1
+  isStaticObject: 0
+--- !u!135 &135613616579332808
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1482660113103954}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 0
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/NewtonVR/Resources/WwiseCollisionSoundPrefab.prefab.meta
+++ b/Assets/NewtonVR/Resources/WwiseCollisionSoundPrefab.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4decd804386d5e04486e233a34fc848d
+timeCreated: 1487016999
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds a Wwise provider for the Collision Sounds framework.

The Wwise events for the collision sounds are Play_sfx_collision_ with the Collision Sound material added to the end, for example Play_sfx_collision_wood and Play_sfx_collision_metal.
The RTPC impactVolume (0 to 100) is used to convey the impact volume to the sound engine.

The WwiseCollisionSoundPrefab prefab should be on a layer that will only collider with any Wwise environments set up.