### PR TITLE
Fix NRE in NVRButtonInputs while controllers are off

### DIFF
--- a/Assets/NewtonVR/NVRHand.cs
+++ b/Assets/NewtonVR/NVRHand.cs
@@ -234,6 +234,7 @@ namespace NewtonVR
 
 
             InputDevice.Initialize(this);
+            UpdateButtonStates();
             InitializeRenderModel();
         }
 


### PR DESCRIPTION
Hi,
this is a fix for the following case:

Querying button state, e.g. `player.LeftHand.Inputs[btn].PressDown` while controllers are off would cause the following error:

	NullReferenceException: Object reference not set to an instance of an object
	NewtonVR.NVRButtonInputs.get_PressDown () (at Assets/NewtonVR/NVRButtonInput.cs:17)

it was a simple fix, but if I overlooked something or took a wrong approach feel free to fix it differently.