### PR TITLE
Fix for controller continuing to vibrate with "Make Controller Invisible On Interaction"

### DIFF
--- a/Assets/NewtonVR/NVRHand.cs
+++ b/Assets/NewtonVR/NVRHand.cs
@@ -696,6 +696,14 @@ namespace NewtonVR
 
                     if (Player.AutomaticallySetControllerTransparency == true)
                     {
+                        //---
+                        // Since the colliders are getting disabled
+                        // the OnTriggerExit method will not be called
+                        // so CurrentlyHoveringOver will not be updated.
+                        // Clear CurrentlyHoveringOver here, it will be setup again once the colliders are reenabled.
+                        //---
+                        CurrentlyHoveringOver.Clear();
+
                         for (int index = 0; index < GhostRenderers.Length; index++)
                         {
                             GhostRenderers[index].enabled = false;


### PR DESCRIPTION
When "Make Controller Invisible On Interaction" is selected and you interact with a NVRInteractableRotator or similar the controller can continue to vibrate after you have stopped the interaction.
When NVRHand sets the controller to Invisible it disables all the hand colliders on the model. Therefore the OnTriggerExit method in NVRHand will not be called when the hand colliders leave the Interactable collider. This means that CurrentlyHoveringOver will not be updated.
Therefore, to fix, CurrentlyHoveringOver is cleared in the SetVisibility method.