### PR TITLE
Fixed FlowerGun AddRelativeForce

### DIFF
--- a/Assets/NewtonVR/Example/NVRExampleGun.cs
+++ b/Assets/NewtonVR/Example/NVRExampleGun.cs
@@ -19,6 +19,10 @@ namespace NewtonVR.Example
             bullet.transform.position = FirePoint.position;
             bullet.transform.forward = FirePoint.forward;
 
+            #if UNITY_2017_2_OR_NEWER 
+            Physics.SyncTransforms();
+            #endif
+            
             bullet.GetComponent<Rigidbody>().AddRelativeForce(BulletForce);
 
             AttachedHand.TriggerHapticPulse(500);


### PR DESCRIPTION
The bullet flower in the flower gun is not working.
It always shoots the flower to the same direction.

That is due to a regression in the Untiy Physics Engine.
They are aware of the bug:
https://issuetracker.unity3d.com/issues/auto-sync-transforms-does-not-sync-correctly-when-using-addrelativeforce

**However** this fix is not even on 2018.1 beta yet.
So it would be nice to add this fix to NewtonVR.
Adding Physics.SyncTransforms() flushes any rotations to the physics engine which then applies the new rotation of the flower and makes it go the right way.


